### PR TITLE
Issue fix goals image height

### DIFF
--- a/sass/components/_successStories.scss
+++ b/sass/components/_successStories.scss
@@ -1,0 +1,28 @@
+#success-stories{
+	background: $light-gray;
+	color: $white;
+	max-height: 600px;
+	height: 30.32vw;
+
+	.success-image-container{
+		max-height: 600px;
+		// height: 100%;
+		width: 100%;
+		padding: 0;
+	}
+
+
+	@media screen and (max-width: $medium) {
+		height: 100%;
+		max-height: none;
+	}
+
+	img{
+		// width: 100%;
+		max-height: 600px;
+		position: relative;
+		left: 0;
+		height: inherit;
+	}
+
+}

--- a/sass/components/goals.scss
+++ b/sass/components/goals.scss
@@ -20,6 +20,8 @@
 
 	#goals-left {
 		padding: 0px;
+		max-height: 446px;
+		height: 29.7vw;
 
 		.goals-image {
 			height: auto;

--- a/src/components/successStories.js
+++ b/src/components/successStories.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import { data } from '../utils/successStoriesData';
+
+class SuccessStories extends Component{
+	constructor(props){
+		super(props);
+
+		this.state = {
+			currentStory: ''
+		}
+	}
+
+	//Sets this.state.currentStory to a random success story.
+	randomStorySelector = () => {
+		//sets randomNum to a number between 0 and length of success stories
+		const randomNum = Math.floor(Math.random() * data.length);
+
+		return this.setState({
+			currentStory: data[randomNum]
+		})
+	}
+
+	componentDidMount(){
+		this.randomStorySelector();
+	}
+
+	render(){
+		const { name, title, excerpt, imageURL } = this.state.currentStory;
+
+		return(
+			<div id="success-stories" className="grid-container">
+
+				{/* left section - image of person */}
+				<div className="column-7 success-image-container">
+					<img alt={name} src={imageURL} />
+				</div>
+
+				{/* right section - success story*/}
+				<div className="column-16">
+					<p>SUCCESS STORY</p>
+					<div className="success-title-container">
+						<p>{name}</p>
+						<p>/</p>
+						<p>{title}</p>
+					</div>
+					<p className="success-excerpt">{excerpt}</p>
+					<div className="success-btn-container">
+						<button>
+							read full story
+						</button>
+					</div>
+				</div>
+
+			</div>
+		);
+	}
+}
+
+export default SuccessStories;


### PR DESCRIPTION
The image container in the goals section was overflowing slightly onto the section below it. 

![image](https://user-images.githubusercontent.com/36907562/59646001-a46ffc80-9129-11e9-88c8-6ceaaae8c1a3.png)

I gave it a `max-height` property of `446px` and a `height` of `29.7vw`, which is the same height & max-height values that the entire section has.

![image](https://user-images.githubusercontent.com/36907562/59646048-e6993e00-9129-11e9-9f65-36c7d0886afe.png)

