### PR TITLE
🚧:Work around for meetup api producing cors error

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const fetch = require('isomorphic-unfetch');
 
 const express = require('express');
 const next = require('next');
@@ -21,6 +22,22 @@ app.prepare().then(() => {
       slug: req.params.id,
     };
     app.render(req, res, actualPage, queryParams);
+  });
+
+  // proxy to make fetch requests to meetup
+  server.use('/meetup', (req, res) => {
+    if(req.method === 'GET'){
+
+      // remove https://meetup/ from apiUrl
+      let apiUrl = req.originalUrl;
+      apiUrl = apiUrl.slice(8);
+
+      fetch(apiUrl)
+      .then(response => response.json())
+      .then(result => {
+        res.json(result);
+      });
+    }
   });
 
   // default

--- a/server.js
+++ b/server.js
@@ -26,17 +26,16 @@ app.prepare().then(() => {
 
   // proxy to make fetch requests to meetup
   server.use('/meetup', (req, res) => {
-    if(req.method === 'GET'){
-
+    if (req.method === 'GET') {
       // remove https://meetup/ from apiUrl
       let apiUrl = req.originalUrl;
       apiUrl = apiUrl.slice(8);
 
       fetch(apiUrl)
-      .then(response => response.json())
-      .then(result => {
-        res.json(result);
-      });
+          .then((response) => response.json())
+          .then((result) => {
+            res.json(result);
+          });
     }
   });
 

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ app.prepare().then(() => {
   // proxy to make fetch requests to meetup
   server.use('/meetup', (req, res) => {
     if (req.method === 'GET') {
-      // remove https://meetup/ from apiUrl
+      // remove /meetup/ from apiUrl
       let apiUrl = req.originalUrl;
       apiUrl = apiUrl.slice(8);
 


### PR DESCRIPTION
This PR is possibly a solution for the meetup api that is needed for issues #21 & issue #8 

![image](https://user-images.githubusercontent.com/36907562/60752200-a2a29780-9f77-11e9-8599-92395571f166.png)

This is the official contributor support for meetup api explicitly saying that they don't support CORS request for anything but oauth authenticated request.

![image](https://user-images.githubusercontent.com/36907562/60752232-ccf45500-9f77-11e9-9466-dc872cb5c4a5.png)

For this work around I added these lines of code to our server.js

![image](https://user-images.githubusercontent.com/36907562/60752742-30818100-9f7e-11e9-90e0-850dd3366ee2.png)

On the front end, you just have to make a fetch request with /meetup/ infront of your meetup api

![image](https://user-images.githubusercontent.com/36907562/60752263-3f653500-9f78-11e9-9176-034ebd89d935.png)

Doing that will allow you to make fetch requests to the meetup api on the front end

![image](https://user-images.githubusercontent.com/36907562/60752268-586de600-9f78-11e9-8515-5a354721de4a.png)


I'm not sure if this will be a security issue or if it'll bring up any other issues. If you see any issues with this, please let me know.