### PR TITLE
Meet up api util

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const fetch = require('isomorphic-unfetch');
 
 const express = require('express');
 const next = require('next');
@@ -21,6 +22,22 @@ app.prepare().then(() => {
       slug: req.params.id,
     };
     app.render(req, res, actualPage, queryParams);
+  });
+
+  // proxy to make fetch requests to meetup
+  server.use('/meetup', (req, res) => {
+    if(req.method === 'GET'){
+
+      // remove https://meetup/ from apiUrl
+      let apiUrl = req.originalUrl;
+      apiUrl = apiUrl.slice(8);
+
+      fetch(apiUrl)
+      .then(response => response.json())
+      .then(result => {
+        res.json(result);
+      });
+    }
   });
 
   // default

--- a/server.js
+++ b/server.js
@@ -26,17 +26,16 @@ app.prepare().then(() => {
 
   // proxy to make fetch requests to meetup
   server.use('/meetup', (req, res) => {
-    if(req.method === 'GET'){
-
+    if (req.method === 'GET') {
       // remove https://meetup/ from apiUrl
       let apiUrl = req.originalUrl;
       apiUrl = apiUrl.slice(8);
 
       fetch(apiUrl)
-      .then(response => response.json())
-      .then(result => {
-        res.json(result);
-      });
+          .then((response) => response.json())
+          .then((result) => {
+            res.json(result);
+          });
     }
   });
 

--- a/server.js
+++ b/server.js
@@ -25,13 +25,11 @@ app.prepare().then(() => {
   });
 
   // proxy to make fetch requests to meetup
-  server.use('/api/events', (req, res) => {
-    if (req.method === 'GET') {
-      let apiUrl = "https://api.meetup.com/2/events?group_urlname=iesd-meetup"
-      fetch(apiUrl)
-      .then((response) => response.json())
-      .then((result) => res.json(result))
-    }// end if 
+  server.get('/api/events', (req, res) => {
+    let apiUrl = "https://api.meetup.com/2/events?group_urlname=iesd-meetup"
+    fetch(apiUrl)
+    .then((response) => response.json())
+    .then((result) => res.json(result))
   });
 
   // default

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ app.prepare().then(() => {
   // proxy to make fetch requests to meetup
   server.use('/meetup', (req, res) => {
     if (req.method === 'GET') {
-      // remove https://meetup/ from apiUrl
+      // remove /meetup/ from apiUrl
       let apiUrl = req.originalUrl;
       apiUrl = apiUrl.slice(8);
 

--- a/server.js
+++ b/server.js
@@ -25,18 +25,13 @@ app.prepare().then(() => {
   });
 
   // proxy to make fetch requests to meetup
-  server.use('/meetup', (req, res) => {
+  server.use('/api/events', (req, res) => {
     if (req.method === 'GET') {
-      // remove /meetup/ from apiUrl
-      let apiUrl = req.originalUrl;
-      apiUrl = apiUrl.slice(8);
-
+      let apiUrl = "https://api.meetup.com/2/events?group_urlname=iesd-meetup"
       fetch(apiUrl)
-          .then((response) => response.json())
-          .then((result) => {
-            res.json(result);
-          });
-    }
+      .then((response) => response.json())
+      .then((result) => res.json(result))
+    }// end if 
   });
 
   // default

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -1,0 +1,20 @@
+import {getEvents} from '../utils/meetupApiUtil'
+import { useState, useEffect } from 'react'
+
+function Events() {
+    const [events, setEvents] = useState([])
+
+    useEffect(() => {
+      getEvents().then( (events) => {
+        setEvents(events)
+      })
+    }, []);
+
+    return (
+      <div className="events">
+      </div>
+    )
+  }
+  
+  export default Events;
+  

--- a/src/utils/meetupApiUtil.js
+++ b/src/utils/meetupApiUtil.js
@@ -1,0 +1,14 @@
+import Fetch from 'isomorphic-unfetch';
+
+export const fetchEvents = () => {
+    let apiUrl = `/api/events`
+
+    return Fetch("/api/events")
+    .then( response => response.json())
+}
+
+export const getEvents = () => {
+    return fetchEvents().then( resp => {
+        return resp.results
+    })
+}


### PR DESCRIPTION
This PR introduces the `meetupApiUtil`, and implements consuming Meetup.com's API from the back-end. `Server.js` was updated to have a `/api/events` endpoint for the app's components, which calls the meetup api version 2. 

There is also a basic implementation of using the call in the `Events` component using react hooks, which should be the main way of integrating our API calls with the components. 