### PR TITLE
Add font size limit of 16px for navbar items on desktop

### DIFF
--- a/sass/components/_navbarDesktop.scss
+++ b/sass/components/_navbarDesktop.scss
@@ -37,6 +37,10 @@
 				font-family: "Book";
 				padding-left: 5px;
 				font-size: calc(.5em + .5vw);
+
+				@media screen and (min-width: 1440px){
+					font-size: 16px;
+				}
 			}
 
 			a:hover{


### PR DESCRIPTION
Navbar items with long words would have the words carry over to the next line, as seen in image below.

![image](https://user-images.githubusercontent.com/36907562/65369696-56c1cf00-dc05-11e9-9724-b926b724c709.png)

I added a font-size limit of 16px for screen sizes 1440px and up. Looks like this now: 

![image](https://user-images.githubusercontent.com/36907562/65369715-9983a700-dc05-11e9-9b89-4f6055450aba.png)
