### PR TITLE
Fix for mobile menu items with children not opening

### DIFF
--- a/sass/components/global/_navigation.scss
+++ b/sass/components/global/_navigation.scss
@@ -85,6 +85,7 @@
     width: 15px;
     position: relative;
     top: -2px;
+    margin-left: 6px;
   }
 }
 

--- a/src/components/global/Nav.js
+++ b/src/components/global/Nav.js
@@ -140,7 +140,7 @@ function getSubList(obj) {
 
 function getMobileSubList(obj) {
   return (
-    <ul className="uk-nav-sub uk-invisible-hover uk-hidden-touch">
+    <ul className="uk-nav-sub uk-invisible-hover">
       {obj.children.map((child) => createListItem(child))}
     </ul>
   );


### PR DESCRIPTION
When on mobile devices the submenu (children) items were not displaying and there was no space between the parent menu item and the SVG to indicate a submenu. 

Testing via Google dev tools shows that the submenu is now opening properly on mobile and there is now better spacing between the parent menu item and the SVG. 

Image of corrected spacing:  
<img width="277" alt="Screen Shot 2019-11-12 at 10 53 05 AM" src="https://user-images.githubusercontent.com/19564687/68704636-77d9d880-0541-11ea-980b-36be3ac2fe3a.png">
