### PR TITLE
Removed mobile hamburger icon and added button to close mobile menu

### DIFF
--- a/sass/components/global/_navigation.scss
+++ b/sass/components/global/_navigation.scss
@@ -6,6 +6,12 @@
     transition: all 2s ease-in-out;
   }
 
+  button.uk-offcanvas-close {
+    color: $white;
+    background: transparent;
+    border: none;
+  }
+
   .uk-visible-toggle:not(:hover):not(:focus) .uk-invisible-hover:not(:focus-within) {
     transition: all 2s ease-in;
     display: none;

--- a/sass/components/global/_navigation.scss
+++ b/sass/components/global/_navigation.scss
@@ -19,7 +19,6 @@
 
   #canvas-logo {
     width: 75px;
-    margin: 0 auto;
     display: block;
     padding: 25px 0;
   }
@@ -107,4 +106,8 @@
       }
     }
   }
+}
+
+#nav-toggle {
+  padding-right: 0;
 }

--- a/src/components/global/Nav.js
+++ b/src/components/global/Nav.js
@@ -52,8 +52,6 @@ function Nav() {
           <a id="nav-toggle" className="uk-navbar-toggle uk-hidden@s"
             href="#"
             uk-toggle="target: #offcanvas-nav">
-            <span uk-navbar-toggle-icon="true"></span>
-
             <span className="uk-margin-small-left nav-text">Menu</span>
           </a>
 
@@ -62,6 +60,7 @@ function Nav() {
 
       <div id="offcanvas-nav" uk-offcanvas="mode: push; flip: true">
         <div className="uk-offcanvas-bar">
+          <button class="uk-offcanvas-close" type="button" uk-close>X</button>
 
           <div className="nav-logo">
             <img id="canvas-logo"

--- a/src/components/global/Nav.js
+++ b/src/components/global/Nav.js
@@ -52,7 +52,7 @@ function Nav() {
           <a id="nav-toggle" className="uk-navbar-toggle uk-hidden@s"
             href="#"
             uk-toggle="target: #offcanvas-nav">
-            <span className="uk-margin-small-left nav-text">Menu</span>
+            <span uk-navbar-toggle-icon="true"></span>
           </a>
 
         </div>
@@ -60,8 +60,6 @@ function Nav() {
 
       <div id="offcanvas-nav" uk-offcanvas="mode: push; flip: true">
         <div className="uk-offcanvas-bar">
-          <button class="uk-offcanvas-close" type="button" uk-close>X</button>
-
           <div className="nav-logo">
             <img id="canvas-logo"
               src="../../static/logos/iesd-initials-white.svg"
@@ -115,11 +113,16 @@ function createListItem(obj, mobile = false) {
     opts["target"] = obj.target;
   }
 
+  if (!obj.children) {
+    opts["uk-toggle"] = "target: #offcanvas-nav";
+  }
+
   return (
     <li key={obj.label.toLowerCase()}
-      className={obj.children && mobile ? "uk-parent uk-visible-toggle" : ""}>
+      className={obj.children && mobile ?
+        "uk-parent uk-visible-toggle" : "close-canvas"}>
       <Link href={obj.url}>
-        <a {...opts} >{obj.label}</a>
+        <a {...opts}>{obj.label}</a>
       </Link>
       {obj.children && mobile && getMobileSubList(obj)}
       {obj.children && !mobile && getSubList(obj)}


### PR DESCRIPTION
Mobile menu required users to click off the navbar in order to close it. 

The suggested fix was to set the navbar to close when a nav link is clicked. However, I ran up against issues with getting the link to apply to only those nav items without children given the way they are mapped.

This fix adds a button to the top right corner allowing the user to close the menu after making their selection. If it is preferred to have the originally suggested behavior of closing upon selection of a nav item I would be happy to work on it some more.

Also, while working on this I noticed that both the mobile hamburger menu icon and the text "Menu" were being rendered.  I removed the hamburger icon and left just the "Menu" text.