### PR TITLE
Fix mobile menu icon color on iOS

### DIFF
--- a/sass/components/global/_navigation.scss
+++ b/sass/components/global/_navigation.scss
@@ -81,7 +81,7 @@
 
 .uk-parent {
   svg {
-    color: $red;
+    fill: $red;
     width: 15px;
     position: relative;
     top: -2px;


### PR DESCRIPTION
SVG icon was rendering as white instead of red on iOS.

Changed CSS property from `color` to `fill` to account for the SVG format.