### PR TITLE
Text bleeds out of hero event: Issue #175

### DIFF
--- a/sass/components/_singleEvent.scss
+++ b/sass/components/_singleEvent.scss
@@ -44,6 +44,10 @@
       font-size: 20px;
     }
   }
+  
+  .event-name-short {
+      font-size: 150%;
+  }
 
   .hero-event-info {
     height: auto;

--- a/src/components/SingleEvent.js
+++ b/src/components/SingleEvent.js
@@ -54,8 +54,8 @@ function SingleEvent() {
         {/* hero event info right side */}
         <div className="hero-event-desc">
 
-          <p className={`event-name ${eventName.length < 30 ?
-            "event-name-short" : ""}`}>
+          <p className={"event-name " + (eventName.length > 30 ?
+            "event-name-short" : "")}>
             {eventName}
           </p>
 


### PR DESCRIPTION
Shrunk the size of the font of the hero single event name when it is too long. Made changes to SingleEvent.js and _singleEvent.scss.